### PR TITLE
Use Context for cancellation and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ load a zip file you want to extract later.
 curl http://localhost:8090/slurp?key=myfile.zip&url=http://leafo.net/file.zip
 ```
 
+## GCS authentication and permissions
+
+The key file in your config should be the PEM-encoded private key for a
+service account which has permissions to view and create objects on your
+chosen GCS bucket.
+
+The bucket needs correct access settings:
+
+- Public access must be enabled, not prevented.
+- Access control should be set to fine-grained ("legacy ACL"), not uniform.

--- a/zipserver/archive.go
+++ b/zipserver/archive.go
@@ -159,6 +159,8 @@ func (a *Archiver) sendZipExtracted(prefix, fname string, limits *ExtractLimits)
 		return nil, errors.Wrap(err, 0)
 	}
 
+	defer zipReader.Close()
+
 	if len(zipReader.File) > limits.MaxNumFiles {
 		err := fmt.Errorf("Too many files in zip (%v > %v)",
 			len(zipReader.File), limits.MaxNumFiles)
@@ -166,8 +168,6 @@ func (a *Archiver) sendZipExtracted(prefix, fname string, limits *ExtractLimits)
 	}
 
 	extractedFiles := []ExtractedFile{}
-
-	defer zipReader.Close()
 
 	fileCount := 0
 	var byteCount uint64

--- a/zipserver/config_test.go
+++ b/zipserver/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,6 +79,10 @@ func Test_Config(t *testing.T) {
 
 	assert.EqualValues(t, "/foo/bar.pem", c.PrivateKeyPath)
 	assert.EqualValues(t, 92, c.MaxFileSize)
+	assert.Equal(t, 3*time.Minute, time.Duration(c.JobTimeout))
+	assert.Equal(t, 10*time.Second, time.Duration(c.FileGetTimeout))
+	assert.Equal(t, 20*time.Second, time.Duration(c.FilePutTimeout))
+	assert.Equal(t, 5*time.Second, time.Duration(c.AsyncNotificationTimeout))
 
 	assert.True(t, c.String() != "")
 }

--- a/zipserver/gcs_storage.go
+++ b/zipserver/gcs_storage.go
@@ -2,6 +2,7 @@ package zipserver
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -20,8 +21,9 @@ var (
 // GcsStorage is a simple interface to Google Cloud Storage
 //
 // Example usage:
-//   storage := NewStorageClient(config)
-//   readCloser, err = storage.GetFile("my_bucket", "my_file")
+//
+//	storage := NewStorageClient(config)
+//	readCloser, err = storage.GetFile("my_bucket", "my_file")
 type GcsStorage struct {
 	jwtConfig *jwt.Config
 }
@@ -119,6 +121,15 @@ func (c *GcsStorage) PutFileWithSetup(bucket, key string, contents io.Reader, se
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("%s: %s", res.Status, body)
+	}
+
 	return nil
 }
 

--- a/zipserver/gcs_storage_test.go
+++ b/zipserver/gcs_storage_test.go
@@ -1,6 +1,7 @@
 package zipserver
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -34,8 +35,10 @@ func withGoogleCloudStorage(t *testing.T, cb ClientFunc) {
 }
 
 func TestGetFile(t *testing.T) {
+	ctx := context.Background()
+
 	withGoogleCloudStorage(t, func(storage Storage, config *Config) {
-		reader, err := storage.GetFile(config.Bucket, "text.txt")
+		reader, err := storage.GetFile(ctx, config.Bucket, "text.txt")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -55,14 +58,16 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestPutAndDeleteFile(t *testing.T) {
+	ctx := context.Background()
+
 	withGoogleCloudStorage(t, func(storage Storage, config *Config) {
-		err := storage.PutFile(config.Bucket, "zipserver_test.txt", strings.NewReader("hello zipserver!"), "text/plain")
+		err := storage.PutFile(ctx, config.Bucket, "zipserver_test.txt", strings.NewReader("hello zipserver!"), "text/plain")
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = storage.DeleteFile(config.Bucket, "zipserver_test.txt")
+		err = storage.DeleteFile(ctx, config.Bucket, "zipserver_test.txt")
 
 		if err != nil {
 			t.Fatal(err)

--- a/zipserver/list_handler.go
+++ b/zipserver/list_handler.go
@@ -39,11 +39,11 @@ func listFromBucket(key string, w http.ResponseWriter, r *http.Request) error {
 	}
 
 	reader, err := storage.GetFile(config.Bucket, key)
-	defer reader.Close()
-
 	if err != nil {
 		return err
 	}
+
+	defer reader.Close()
 
 	body, err := io.ReadAll(reader)
 

--- a/zipserver/storage.go
+++ b/zipserver/storage.go
@@ -1,6 +1,7 @@
 package zipserver
 
 import (
+	"context"
 	"io"
 	"net/http"
 )
@@ -10,8 +11,8 @@ type StorageSetupFunc func(*http.Request) error
 
 // Storage is a place we can get files from, put files into, or delete files from
 type Storage interface {
-	GetFile(bucket, key string) (io.ReadCloser, error)
-	PutFile(bucket, key string, contents io.Reader, mimeType string) error
-	PutFileWithSetup(bucket, key string, contents io.Reader, setup StorageSetupFunc) error
-	DeleteFile(bucket, key string) error
+	GetFile(ctx context.Context, bucket, key string) (io.ReadCloser, error)
+	PutFile(ctx context.Context, bucket, key string, contents io.Reader, mimeType string) error
+	PutFileWithSetup(ctx context.Context, bucket, key string, contents io.Reader, setup StorageSetupFunc) error
+	DeleteFile(ctx context.Context, bucket, key string) error
 }


### PR DESCRIPTION
This includes preparatory work from #7 that:

- Uses the stdlib `Context` to control job cancellation, abort on client disconnection, and set timeouts for tasks
- Adds timeouts to `Config`
- Fixes a couple uncaught failures
- Adds some GCS setup info to the readme

Once merged I will rebase #7 on master.

## Breaking library changes

In the `zipserver` package:

- All methods of the `Storage` interface now take a Context argument.
- `Archiver.ExtractZip()` and `Archiver.UploadZipFromFile()` now take a Context argument.